### PR TITLE
Absolute path for ULWGL & Multi args support.

### DIFF
--- a/gamelauncher.sh
+++ b/gamelauncher.sh
@@ -32,6 +32,7 @@ export PROTON_CRASH_REPORT_DIR='/tmp/ULWGL_crashreports'
 export FONTCONFIG_PATH=''
 
 export EXE="$2"
-export LAUNCHARGS="$3"
+shift 2
+export LAUNCHARGS="$@"
 
-"$DIRNAME/ULWGL" --verb=waitforexitandrun -- "$PROTONPATH"/proton waitforexitandrun "$EXE" "$LAUNCHARGS"
+"$DIRNAME/ULWGL" --verb=waitforexitandrun -- "$PROTONPATH"/proton waitforexitandrun "$EXE" $LAUNCHARGS

--- a/gamelauncher.sh
+++ b/gamelauncher.sh
@@ -14,6 +14,9 @@ if [[ $WINEPREFIX ]]; then
    ln -s "$WINEPREFIX" "$WINEPREFIX"/pfx
    touch "$WINEPREFIX"/tracked_files
 fi
+
+DIRNAME=$(dirname $0)
+
 export PROTONPATH="$1"
 export STEAM_COMPAT_APP_ID="$GAMEID"
 export SteamAppId="$STEAM_COMPAT_APP_ID"
@@ -31,4 +34,4 @@ export FONTCONFIG_PATH=''
 export EXE="$2"
 export LAUNCHARGS="$3"
 
-./ULWGL --verb=waitforexitandrun -- "$PROTONPATH"/proton waitforexitandrun "$EXE" "$LAUNCHARGS"
+"$DIRNAME/ULWGL" --verb=waitforexitandrun -- "$PROTONPATH"/proton waitforexitandrun "$EXE" "$LAUNCHARGS"


### PR DESCRIPTION
- Absolute path for ULWGL so `gamelauncher.sh` can be executed from any directory.
- Multiple arguments supports.